### PR TITLE
fix: apply Circle/Arc SDK compliance fixes

### DIFF
--- a/src/core/routes.ts
+++ b/src/core/routes.ts
@@ -8,15 +8,11 @@ import crypto from 'crypto';
 import rateLimit from 'express-rate-limit';
 import { isAddress, isHex, verifyMessage, createWalletClient, createPublicClient, http, encodeFunctionData, formatUnits, parseUnits } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
+import { arcTestnet } from 'viem/chains';
 import { initiateUserControlledWalletsClient } from '@circle-fin/user-controlled-wallets';
 
-// Arc Testnet chain definition (viem does not bundle it yet, define inline)
-const arcTestnetChain = {
-    id: 5042002,
-    name: 'Arc Testnet',
-    nativeCurrency: { name: 'USDC', symbol: 'USDC', decimals: 18 },
-    rpcUrls: { default: { http: ['https://rpc.testnet.arc.network'] } },
-} as const;
+// Arc Testnet chain — imported from viem/chains (verified: exports chain ID 5042002)
+// Per use-arc.md: "Arc Testnet is available by default in Viem — a custom chain definition is NEVER required."
 
 // Arc Testnet CCTP contracts (verified from docs.arc.network official docs)
 const ARC_MESSAGE_TRANSMITTER = '0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275' as `0x${string}`;
@@ -198,7 +194,9 @@ coreRouter.post('/circle/get-wallet', sessionLimiter, async (req: Request, res: 
         try {
             const createRes = await circleClient.createWallet({
                 userToken,
-                idempotencyKey: crypto.randomUUID(),
+                // Deterministic key derived from userId — prevents duplicate wallet creation on retries.
+                // crypto.randomUUID() would defeat the purpose of idempotency.
+                idempotencyKey: `create-wallet-${userId}`,
                 blockchains: ['ARC-TESTNET' as any],
                 accountType: 'SCA',
             });
@@ -402,11 +400,11 @@ async function executeCctpFinalizationInBackground(
         const account = privateKeyToAccount(sellerKey as `0x${string}`);
         const arcWalletClient = createWalletClient({
             account,
-            chain: arcTestnetChain,
+            chain: arcTestnet,
             transport: http(),
         });
         const arcPublicClient = createPublicClient({
-            chain: arcTestnetChain,
+            chain: arcTestnet,
             transport: http(),
         });
 

--- a/src/ui/paywall.js
+++ b/src/ui/paywall.js
@@ -403,6 +403,9 @@ async function handleEmailLogin() {
         arcSdk = new W3SSdk({
             appSettings: { appId: viewerState.appId }
         });
+        // REQUIRED per Circle UCW docs: establishes session with Circle's service via iframe.
+        // Without this call, sdk.execute() silently fails and no PIN popup appears.
+        arcSdk.getDeviceId();
         arcSdk.setAuthentication({
             userToken: viewerState.userToken,
             encryptionKey: viewerState.encryptionKey,
@@ -441,7 +444,11 @@ async function handleEmailLogin() {
     }
 }
 
-async function getOrCreateArcWallet() {
+async function getOrCreateArcWallet(retries = 0) {
+    if (retries > 10) {
+        throw new Error('No se pudo configurar la wallet. Por favor intenta de nuevo.');
+    }
+
     const walletRes = await fetch(ARC_API_BASE + '/api/core/circle/get-wallet', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -460,7 +467,7 @@ async function getOrCreateArcWallet() {
             });
         });
         // Re-fetch to get the walletId now that it's been created
-        return getOrCreateArcWallet();
+        return getOrCreateArcWallet(retries + 1);
     }
 
     // Circle error 155106: wallet just initialized, still indexing on Circle's side.
@@ -468,7 +475,7 @@ async function getOrCreateArcWallet() {
     if (walletData.status === 'indexing') {
         setLoginStatus('Setting up your wallet…');
         await new Promise(resolve => setTimeout(resolve, 1500));
-        return getOrCreateArcWallet();
+        return getOrCreateArcWallet(retries + 1);
     }
 
     return walletData;


### PR DESCRIPTION
- add getDeviceId() call after W3SSdk init
- use deterministic idempotency key for wallet creation
- add retry limit to getOrCreateArcWallet
- replace custom arcTestnet chain with viem/chains import