### PR TITLE
chore: align sidecar version to 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
   <!-- Row 1: Status Badges -->
   <a href="https://github.com/JaDi03/tessera/actions"><img src="https://img.shields.io/badge/build-passing-brightgreen?style=for-the-badge&logo=githubactions&logoColor=white" alt="Build Status"></a>
-  <a href="https://github.com/JaDi03/tessera/releases"><img src="https://img.shields.io/badge/version-1.0.0-blue?style=for-the-badge" alt="Version"></a>
+  <a href="https://github.com/JaDi03/tessera/releases"><img src="https://img.shields.io/badge/version-1.3.1-blue?style=for-the-badge" alt="Version"></a>
   <a href="https://github.com/JaDi03/tessera/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-yellow?style=for-the-badge" alt="License"></a>
   <br>
   <!-- Row 2: Tech Stack Badges -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 *Per-second nanopayments powered by [Circle x402](https://www.circle.com/nanopayments) & [Arc](https://www.arc.network)*
 
 [![Build Passing](https://img.shields.io/badge/build-passing-brightgreen?style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/JaDi03/tessera/actions)
-[![Version](https://img.shields.io/badge/version-1.0.0-blue?style=for-the-badge)](https://github.com/JaDi03/tessera/releases)
+[![Version](https://img.shields.io/badge/version-1.3.1-blue?style=for-the-badge)](https://github.com/JaDi03/tessera/releases)
 [![License](https://img.shields.io/badge/license-Apache_2.0-yellow?style=for-the-badge)](https://github.com/JaDi03/tessera/blob/main/LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tessera",
-  "version": "1.0.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tessera",
-      "version": "1.0.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@circle-fin/adapter-viem-v2": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tessera",
-  "version": "1.0.0",
+  "version": "1.3.1",
   "description": "Per-second streaming payments for self-hosted platforms, powered by Circle x402.",
   "main": "src/index.ts",
   "scripts": {

--- a/src/core/instance-info.ts
+++ b/src/core/instance-info.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
+import { TESSERA_VERSION } from '../version';
 
 const instanceInfoRouter = Router();
 
@@ -30,7 +31,7 @@ instanceInfoRouter.get('/instance-info', (req, res) => {
     if (!adminWallet) {
         return res.status(503).json({
             error: 'Tessera not fully configured: Admin wallet address is missing. Configure it in the PeerTube plugin settings UI.',
-            tesseraVersion: '1.2.0',
+            tesseraVersion: TESSERA_VERSION,
         });
     }
 
@@ -38,7 +39,7 @@ instanceInfoRouter.get('/instance-info', (req, res) => {
         adminWallet,
         displayFee,
         originFee,
-        tesseraVersion: '1.2.0',
+        tesseraVersion: TESSERA_VERSION,
     });
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import circleRouter from './core/circle-routes';
 import instanceInfoRouter from './core/instance-info';
 import { sessionService } from './core/session';
 import type { Connector, ConnectorConfig } from './core/types';
+import { TESSERA_VERSION } from './version';
 
 /**
  * Connector Registry
@@ -106,7 +107,7 @@ export async function createServer(connectors: ConnectorConfig[]) {
 
             res.json({ 
                 status: 'healthy', 
-                version: '1.0.0',
+                version: TESSERA_VERSION,
                 gateway: gatewayHealth.ok ? 'connected' : 'degraded',
                 activeSessions: sessionService.getActiveSessionCount(),
             });

--- a/src/version.spec.ts
+++ b/src/version.spec.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import { TESSERA_VERSION } from './version';
+
+describe('TESSERA_VERSION', () => {
+    it('matches package.json and is semver', () => {
+        const pkg = JSON.parse(
+            readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+        ) as { version: string };
+        expect(TESSERA_VERSION).toBe(pkg.version);
+        expect(TESSERA_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,8 +1,8 @@
 import { createRequire } from 'module';
 import path from 'path';
 
-const require = createRequire(__filename);
-const pkg = require(path.join(__dirname, '..', 'package.json')) as { version?: string };
+const requirePkg = createRequire(__filename);
+const pkg = requirePkg(path.join(__dirname, '..', 'package.json')) as { version?: string };
 
 if (!pkg.version || typeof pkg.version !== 'string') {
     throw new Error('package.json is missing a version field');

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,12 @@
+import { createRequire } from 'module';
+import path from 'path';
+
+const require = createRequire(__filename);
+const pkg = require(path.join(__dirname, '..', 'package.json')) as { version?: string };
+
+if (!pkg.version || typeof pkg.version !== 'string') {
+    throw new Error('package.json is missing a version field');
+}
+
+/** Sidecar version. Single source of truth: root package.json. */
+export const TESSERA_VERSION: string = pkg.version;


### PR DESCRIPTION
## Summary
- Bump package version from 1.0.0 to 1.3.1 (patch after tag v1.3.0; main had already moved on).
- Read version from package.json so `/health` and `/api/tessera/instance-info` cannot drift (they were 1.0.0 and 1.2.0).
- Update README and docs index badges only.

## Test plan
- [ ] CI green (typecheck, lint, test)
- [ ] `GET /health` returns `version: 1.3.1`
- [ ] `GET /api/tessera/instance-info` returns `tesseraVersion: 1.3.1`
- [ ] No billing/paywall behavior change