### PR TITLE
feat(core): require Circle wallet proof on tips

### DIFF
--- a/CONNECTOR_SPEC.md
+++ b/CONNECTOR_SPEC.md
@@ -142,14 +142,14 @@ Tessera does **not** have to be on the public internet if the platform server an
 
 ### Tips flow (browser)
 
-`POST /v1/tips` is called from the **browser** (paywall tip button), not from your ingest HMAC server. Your server may also POST `tips` if you already have a funded Gateway session for that `userId`, but the usual path is:
+`POST /v1/tips` is called from the **browser** (paywall tip button), not from your ingest HMAC server. A server POST is only valid if it also sends a live Circle `userToken` and the session `returnAddress`. The usual path is:
 
 1. Load `paywall.bundle.js`.
 2. `initTipMode(creatorWallet, tipAmount)`.
 3. Viewer signs in (email or Google) and funds wallet in the paywall UI.
 4. Paywall calls `POST /api/core/register-session` (Gateway deposit). This requires a valid `userId` and Circle `userToken`.
-5. Viewer clicks tip → paywall calls `POST /api/core/v1/tips` with `{ userId, payoutAddress, amount }`.
-6. `402` = insufficient Gateway balance. `404` = no session for `userId` (viewer has not completed step 4).
+5. Viewer clicks tip → paywall calls `POST /api/core/v1/tips` with `{ userId, payoutAddress, amount, userToken, returnAddress }`.
+6. `401` = Circle session does not own `returnAddress`, or it does not match the stored Gateway session. `402` = insufficient Gateway balance. `404` = no session for `userId` (viewer has not completed step 4).
 
 Server-side `start` / `stop` do **not** fund the viewer wallet. Funding is always through the paywall.
 
@@ -237,15 +237,17 @@ Response: `{ "status": "session_stopped" }`
 
 ### `POST /v1/tips`
 
-One amount, now. **No ingest HMAC.** Requires a Gateway session for `userId` (see §2 tips flow).
+One amount, now. **No ingest HMAC.** Requires a Gateway session for `userId` plus Circle proof that `userToken` owns `returnAddress`, and that address matches the stored session (same pattern as `sync-session`).
 
-Typical native events: tip button click (browser); or server gesture if session already funded.
+Typical native events: tip button click (browser). Do not POST `tips` from the plugin server unless you also hold a live Circle `userToken` for that viewer.
 
 ```json
 {
   "userId": "email:viewer@example.com",
   "payoutAddress": "0x...",
-  "amount": "0.100000"
+  "amount": "0.100000",
+  "userToken": "<circle-user-token>",
+  "returnAddress": "0x..."
 }
 ```
 
@@ -413,6 +415,8 @@ Each entry is a `resourceId` your connector sent on `start` (or via `tips`) that
 | 400 | `start` | `splits` fractions sum > 1 |
 | 400 | `stop` | Missing `userId` |
 | 401 | `start`, `stop` | Missing/invalid HMAC, expired timestamp (> 60 s), or duplicate nonce |
+| 400 | `tips` | Missing `userToken` or `returnAddress` |
+| 401 | `tips` | Circle session does not own `returnAddress`, or it does not match the stored Gateway session |
 | 402 | `tips` | Insufficient Gateway balance |
 | 404 | `tips` | No Gateway session for `userId` (viewer has not funded wallet) |
 | 500 | `stop`, creator | Settlement failed or Tessera server error |

--- a/src/core/routes.spec.ts
+++ b/src/core/routes.spec.ts
@@ -3,6 +3,7 @@ import instanceInfoRouter from './instance-info';
 import coreRouter from './routes';
 import { statsService } from './stats';
 import { walletService } from './wallet';
+import { sessionService } from './session';
 import * as circleRoutes from './circle-routes';
 import { Request, Response } from 'express';
 import * as fs from 'fs';
@@ -262,5 +263,76 @@ describe('sync-session Endpoint', () => {
         } as Request, res);
         expect(getStatus()).toBe(200);
         expect(getJson()).toEqual({ status: 'synced', privateKey });
+    });
+});
+
+describe('POST /v1/tips', () => {
+    const returnAddress = '0x1111222233334444555566667777888899990000';
+    const payoutAddress = '0x2222333344445555666677778888999900001111';
+    const privateKey = ('0x' + 'ab'.repeat(32)) as `0x${string}`;
+    const tipBody = {
+        userId: 'social:abc',
+        payoutAddress,
+        amount: '0.100000',
+        userToken: 'x'.repeat(40),
+        returnAddress,
+    };
+    let handler: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        handler = getRouteHandler('/v1/tips');
+    });
+
+    it('rejects missing Circle proof fields', async () => {
+        const { res, getStatus, getJson } = mockRes();
+        await handler({
+            body: { userId: 'social:abc', payoutAddress, amount: '0.100000' },
+        } as Request, res);
+        expect(getStatus()).toBe(400);
+        expect(getJson().error).toMatch(/Missing/);
+    });
+
+    it('rejects when Circle ownership fails', async () => {
+        vi.spyOn(circleRoutes, 'verifyCircleWalletOwnership').mockResolvedValue('unauthorized');
+        const { res, getStatus } = mockRes();
+        await handler({ body: tipBody } as Request, res);
+        expect(getStatus()).toBe(401);
+    });
+
+    it('rejects when no Gateway session exists', async () => {
+        vi.spyOn(circleRoutes, 'verifyCircleWalletOwnership').mockResolvedValue('ok');
+        vi.spyOn(walletService, 'hasSessionRecord').mockReturnValue(false);
+        const { res, getStatus } = mockRes();
+        await handler({ body: tipBody } as Request, res);
+        expect(getStatus()).toBe(404);
+    });
+
+    it('rejects returnAddress mismatch against stored session', async () => {
+        vi.spyOn(circleRoutes, 'verifyCircleWalletOwnership').mockResolvedValue('ok');
+        vi.spyOn(walletService, 'hasSessionRecord').mockReturnValue(true);
+        vi.spyOn(walletService, 'getSessionRecord').mockReturnValue({
+            privateKey,
+            returnAddress: '0x9999999999999999999999999999999999999999',
+        } as any);
+        const { res, getStatus } = mockRes();
+        await handler({ body: tipBody } as Request, res);
+        expect(getStatus()).toBe(401);
+    });
+
+    it('pays after Circle ownership proof and matching session', async () => {
+        const pay = vi.fn().mockResolvedValue({ success: true });
+        vi.spyOn(circleRoutes, 'verifyCircleWalletOwnership').mockResolvedValue('ok');
+        vi.spyOn(walletService, 'hasSessionRecord').mockReturnValue(true);
+        vi.spyOn(walletService, 'getSessionRecord').mockReturnValue({
+            privateKey,
+            returnAddress,
+        } as any);
+        vi.spyOn(sessionService, 'getGatewayClientForUser').mockReturnValue({ pay } as any);
+        const { res, getStatus, getJson } = mockRes();
+        await handler({ body: tipBody } as Request, res);
+        expect(getStatus()).toBe(200);
+        expect(getJson()).toEqual({ status: 'success', amount: '0.100000', payoutAddress });
+        expect(pay).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/core/routes.ts
+++ b/src/core/routes.ts
@@ -133,12 +133,37 @@ coreRouter.post('/v1/sessions/stop', sessionLimiter, verifyIngestSignature, asyn
 });
 
 coreRouter.post('/v1/tips', sessionLimiter, async (req: Request, res: Response) => {
-    const { userId, payoutAddress, amount } = req.body;
+    const { userId, payoutAddress, amount, userToken, returnAddress } = req.body;
 
-    if (!userId || !payoutAddress || !amount) return res.status(400).json({ error: 'Missing userId, payoutAddress, or amount' });
+    if (!userId || !payoutAddress || !amount || !userToken || !returnAddress) {
+        return res.status(400).json({ error: 'Missing userId, payoutAddress, amount, userToken, or returnAddress' });
+    }
+    if (!isValidViewerUserId(userId)) {
+        return res.status(400).json({ error: 'Invalid userId' });
+    }
     if (!isAddress(payoutAddress)) return res.status(400).json({ error: 'Invalid payoutAddress' });
+    if (!isAddress(returnAddress)) return res.status(400).json({ error: 'Invalid returnAddress' });
+    if (typeof userToken !== 'string' || userToken.length < 20 || userToken.length > 8192) {
+        return res.status(400).json({ error: 'Invalid userToken' });
+    }
 
     try {
+        const ownership = await verifyCircleWalletOwnership(String(userToken), returnAddress);
+        if (ownership === 'unauthorized') {
+            return res.status(401).json({ error: 'Circle session does not own this wallet.' });
+        }
+        if (ownership === 'error') {
+            return res.status(503).json({ error: 'Unable to verify Circle wallet ownership. Try again.' });
+        }
+
+        if (!walletService.hasSessionRecord(userId)) {
+            return res.status(404).json({ error: 'No active session found for this user.' });
+        }
+        const sessionRecord = walletService.getSessionRecord(userId);
+        if (!addressesEqual(sessionRecord.returnAddress, returnAddress)) {
+            return res.status(401).json({ error: 'Return address does not match existing session.' });
+        }
+
         const gatewayClient = sessionService.getGatewayClientForUser(userId);
         if (!gatewayClient) return res.status(404).json({ error: 'No active session found for this user.' });
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -29,6 +29,10 @@ export interface TipRequest {
     payoutAddress: string;
     /** Decimal string in USDC, e.g. "0.100000". */
     amount: string;
+    /** Circle userToken: must own returnAddress. */
+    userToken: string;
+    /** UCW SCA address; must match the stored Gateway session. */
+    returnAddress: string;
 }
 
 export interface CashierConfig {

--- a/src/ui/paywall.js
+++ b/src/ui/paywall.js
@@ -3294,6 +3294,8 @@ window.arcShowTipButton = function (creatorWallet, tipAmount) {
                         userId: viewerState.userId,
                         payoutAddress: creatorWallet,
                         amount: amount.toFixed(6),
+                        userToken: viewerState.userToken,
+                        returnAddress: viewerState.walletAddress,
                     }),
                 });
 
@@ -3308,9 +3310,10 @@ window.arcShowTipButton = function (creatorWallet, tipAmount) {
                 } else {
                     console.error('[Tessera] Tip failed: HTTP ' + res.status);
 
+                    // 401: Circle session does not own this wallet. Re-onboard.
                     // 404/402: need deposit or session. Do not silent-register here
                     // (that delayed the deposit modal by seconds when unfunded).
-                    if (res.status === 404 || res.status === 402) {
+                    if (res.status === 401 || res.status === 404 || res.status === 402) {
                         btn.textContent = `\u2764\uFE0F Support $${amount.toFixed(2)}`;
                         void refreshStatus();
                         openTipOnboarding();


### PR DESCRIPTION
## Summary
- `POST /api/core/v1/tips` now uses the same Circle ownership check as `sync-session` (`userToken` + `returnAddress` must match the stored Gateway session).
