### PR TITLE
feat(core): require Circle proof on session money routes

### DIFF
--- a/src/core/routes.spec.ts
+++ b/src/core/routes.spec.ts
@@ -336,3 +336,49 @@ describe('POST /v1/tips', () => {
         expect(pay).toHaveBeenCalledTimes(1);
     });
 });
+
+describe('POST /cash-out', () => {
+    let handler: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        handler = getRouteHandler('/cash-out');
+    });
+
+    it('rejects missing Circle proof fields', async () => {
+        const { res, getStatus, getJson } = mockRes();
+        await handler({ body: { userId: 'social:abc' }, headers: {} } as Request, res);
+        expect(getStatus()).toBe(400);
+        expect(getJson().error).toMatch(/Missing/);
+    });
+
+    it('rejects when Circle ownership fails', async () => {
+        vi.spyOn(circleRoutes, 'verifyCircleWalletOwnership').mockResolvedValue('unauthorized');
+        const { res, getStatus } = mockRes();
+        await handler({
+            body: {
+                userId: 'social:abc',
+                userToken: 'x'.repeat(40),
+                returnAddress: '0x1111222233334444555566667777888899990000',
+            },
+            headers: {},
+        } as Request, res);
+        expect(getStatus()).toBe(401);
+    });
+});
+
+describe('POST /session-balance', () => {
+    let handler: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        handler = getRouteHandler('/session-balance');
+    });
+
+    it('rejects missing Circle proof fields', async () => {
+        const { res, getStatus, getJson } = mockRes();
+        await handler({ body: { userId: 'social:abc' }, headers: {} } as Request, res);
+        expect(getStatus()).toBe(400);
+        expect(getJson().error).toMatch(/Missing/);
+    });
+});

--- a/src/core/routes.ts
+++ b/src/core/routes.ts
@@ -42,6 +42,51 @@ const coreRouter = Router();
 const PORT = process.env.PORT || 7878;
 const SIDECAR_URL = `http://localhost:${PORT}`;
 
+function circleProofFromRequest(req: Request): { userToken: unknown; returnAddress: unknown } {
+    const body = (req.body || {}) as Record<string, unknown>;
+    const headerToken = req.headers['x-tessera-user-token'];
+    const headerAddr = req.headers['x-tessera-return-address'];
+    return {
+        userToken: body.userToken || (typeof headerToken === 'string' ? headerToken : undefined),
+        returnAddress: body.returnAddress || (typeof headerAddr === 'string' ? headerAddr : undefined),
+    };
+}
+
+async function requireViewerSessionOwnership(
+    userId: unknown,
+    userToken: unknown,
+    returnAddress: unknown,
+): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
+    if (!userId || !userToken || !returnAddress) {
+        return { ok: false, status: 400, error: 'Missing userId, userToken, or returnAddress' };
+    }
+    if (!isValidViewerUserId(userId)) {
+        return { ok: false, status: 400, error: 'Invalid userId' };
+    }
+    if (!isAddress(String(returnAddress))) {
+        return { ok: false, status: 400, error: 'Invalid returnAddress' };
+    }
+    if (typeof userToken !== 'string' || userToken.length < 20 || userToken.length > 8192) {
+        return { ok: false, status: 400, error: 'Invalid userToken' };
+    }
+
+    const ownership = await verifyCircleWalletOwnership(String(userToken), String(returnAddress));
+    if (ownership === 'unauthorized') {
+        return { ok: false, status: 401, error: 'Circle session does not own this wallet.' };
+    }
+    if (ownership === 'error') {
+        return { ok: false, status: 503, error: 'Unable to verify Circle wallet ownership. Try again.' };
+    }
+    if (!walletService.hasSessionRecord(String(userId))) {
+        return { ok: false, status: 404, error: 'No active session found for this user.' };
+    }
+    const sessionRecord = walletService.getSessionRecord(String(userId));
+    if (!addressesEqual(sessionRecord.returnAddress, String(returnAddress))) {
+        return { ok: false, status: 401, error: 'Return address does not match existing session.' };
+    }
+    return { ok: true };
+}
+
 // ─── x402 Payment Gate ───────────────────────────────────────────────────────
 
 coreRouter.get('/stream-access', (req: Request, res: Response, next: NextFunction) => {
@@ -353,9 +398,11 @@ coreRouter.post('/register-session', sessionLimiter, async (req: Request, res: R
     }
 });
 
-coreRouter.post('/end-session', async (req: Request, res: Response) => {
+coreRouter.post('/end-session', sessionLimiter, async (req: Request, res: Response) => {
     const { userId } = req.body;
-    if (!userId) return res.status(400).json({ error: 'Missing userId' });
+    const proof = circleProofFromRequest(req);
+    const owned = await requireViewerSessionOwnership(userId, proof.userToken, proof.returnAddress);
+    if (!owned.ok) return res.status(owned.status).json({ error: owned.error });
     try {
         await sessionService.recordPartAndSettle(userId);
         return res.json({ status: 'session_ended' });
@@ -365,9 +412,11 @@ coreRouter.post('/end-session', async (req: Request, res: Response) => {
     }
 });
 
-coreRouter.post('/cash-out', async (req: Request, res: Response) => {
+coreRouter.post('/cash-out', sessionLimiter, async (req: Request, res: Response) => {
     const { userId } = req.body;
-    if (!userId) return res.status(400).json({ error: 'Missing userId' });
+    const proof = circleProofFromRequest(req);
+    const owned = await requireViewerSessionOwnership(userId, proof.userToken, proof.returnAddress);
+    if (!owned.ok) return res.status(owned.status).json({ error: owned.error });
 
     try {
         if (sessionService.hasActiveSession(userId)) await sessionService.recordPartAndSettle(userId);
@@ -392,17 +441,21 @@ coreRouter.post('/cash-out', async (req: Request, res: Response) => {
     }
 });
 
-coreRouter.get('/session-status', (req: Request, res: Response) => {
-    const userId = req.query.userId as string;
-    if (!userId) return res.status(400).json({ error: 'Missing userId' });
+coreRouter.post('/session-status', async (req: Request, res: Response) => {
+    const userId = req.body?.userId as string;
+    const proof = circleProofFromRequest(req);
+    const owned = await requireViewerSessionOwnership(userId, proof.userToken, proof.returnAddress);
+    if (!owned.ok) return res.status(owned.status).json({ error: owned.error });
     return walletService.hasSessionRecord(userId)
         ? res.status(200).json({ status: 'active' })
         : res.status(404).json({ error: 'No active session key found' });
 });
 
-coreRouter.get('/session-balance', async (req: Request, res: Response) => {
-    const userId = req.query.userId as string;
-    if (!userId) return res.status(400).json({ error: 'Missing userId' });
+coreRouter.post('/session-balance', async (req: Request, res: Response) => {
+    const userId = req.body?.userId as string;
+    const proof = circleProofFromRequest(req);
+    const owned = await requireViewerSessionOwnership(userId, proof.userToken, proof.returnAddress);
+    if (!owned.ok) return res.status(owned.status).json({ error: owned.error });
     try {
         if (!walletService.hasSessionRecord(userId)) return res.status(404).json({ error: 'Session not found' });
         const sessionRecord = walletService.getSessionRecord(userId);
@@ -417,7 +470,9 @@ coreRouter.get('/session-balance', async (req: Request, res: Response) => {
 
 coreRouter.post('/topup-session', sessionLimiter, async (req: Request, res: Response) => {
     const { userId, expectFunds } = req.body;
-    if (!userId) return res.status(400).json({ error: 'Missing userId' });
+    const proof = circleProofFromRequest(req);
+    const owned = await requireViewerSessionOwnership(userId, proof.userToken, proof.returnAddress);
+    if (!owned.ok) return res.status(owned.status).json({ error: owned.error });
     try {
         if (!walletService.hasSessionRecord(userId)) return res.status(404).json({ error: 'Session not found' });
         const sessionRecord = walletService.getSessionRecord(userId);

--- a/src/ui/paywall.js
+++ b/src/ui/paywall.js
@@ -243,6 +243,29 @@ function hasResumableCircleSession() {
     );
 }
 
+function circleProofFields() {
+    return {
+        userToken: viewerState.userToken,
+        returnAddress: viewerState.walletAddress,
+    };
+}
+
+function fetchSessionBalance(userId) {
+    return fetch(ARC_API_BASE + '/api/core/session-balance', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: userId || viewerState.userId, ...circleProofFields() }),
+    });
+}
+
+function fetchSessionStatus(userId) {
+    return fetch(ARC_API_BASE + '/api/core/session-status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: userId || viewerState.userId, ...circleProofFields() }),
+    });
+}
+
 // Auth is email OTP or social login only. Legacy PIN-era identities (arc_*)
 // cannot resume a session, so drop them: the viewer signs in with email/social.
 if (viewerState.userId
@@ -452,7 +475,7 @@ async function checkAutoUnlock() {
         const minReq = getRequiredMinBalance();
 
         // First try: existing session record (returning user / already registered).
-        let balRes = await fetch(ARC_API_BASE + '/api/core/session-balance?userId=' + viewerState.userId);
+        let balRes = await fetchSessionBalance(viewerState.userId);
         sessionBalanceStatus = balRes.status;
         // #region agent log
         agentDebugLog('H3', 'session-balance first', { status: balRes.status });
@@ -2193,7 +2216,7 @@ function startBalancePolling() {
         const minReq = getRequiredMinBalance();
         // Prefer Gateway: that is what billing spends. Same source as tip widget.
         try {
-            const balRes = await fetch(ARC_API_BASE + '/api/core/session-balance?userId=' + viewerState.userId);
+            const balRes = await fetchSessionBalance(viewerState.userId);
             if (balRes.ok) {
                 const balData = await balRes.json();
                 const gatewayAvailable = Number(balData.gatewayAvailable || '0');
@@ -2284,7 +2307,7 @@ async function handleUnlock() {
         // Check if Gateway already funded (returning user)
         let skipDeposit = false;
         try {
-            const balRes = await fetch(ARC_API_BASE + '/api/core/session-balance?userId=' + viewerState.userId);
+            const balRes = await fetchSessionBalance(viewerState.userId);
             if (balRes.ok) {
                 const balData = await balRes.json();
                 if (Number(balData.gatewayAvailable) >= getRequiredMinBalance()) {
@@ -2595,7 +2618,7 @@ function startSessionTimer() {
     let lastWithdrawableBalance = null;
 
     // Fetch the initial gateway balance immediately so video cost is accurate and displayed from the start
-    fetch(ARC_API_BASE + '/api/core/session-balance?userId=' + viewerState.userId)
+    fetchSessionBalance(viewerState.userId)
         .then(function (r) { return r.ok ? r.json() : null; })
         .then(function (data) {
             if (data) {
@@ -2654,7 +2677,7 @@ function startSessionTimer() {
 
         if (tickCount % 5 === 0) {
             try {
-                const statusRes = await fetch(ARC_API_BASE + '/api/core/session-status?userId=' + viewerState.userId);
+                const statusRes = await fetchSessionStatus(viewerState.userId);
                 if (statusRes.status === 404) {
                     clearInterval(window.sessionTimer);
                     const sm = document.getElementById('arc-session-manager');
@@ -2663,7 +2686,7 @@ function startSessionTimer() {
                     if (isTipMode) return;
                     initPaywall();
                 } else if (statusRes.ok) {
-                    const balanceRes = await fetch(ARC_API_BASE + '/api/core/session-balance?userId=' + viewerState.userId);
+                    const balanceRes = await fetchSessionBalance(viewerState.userId);
                     if (balanceRes.ok) {
                         const data = await balanceRes.json();
                         const withdrawable = Number(data.gatewayAvailable);
@@ -2714,7 +2737,7 @@ async function handleTopUp(depositAmount) {
         const flushRes = await fetch(ARC_API_BASE + '/api/core/topup-session', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ userId: viewerState.userId }),
+            body: JSON.stringify({ userId: viewerState.userId, ...circleProofFields() }),
         });
         if (flushRes.ok) {
             const flushData = await flushRes.json();
@@ -2760,7 +2783,7 @@ async function handleTopUp(depositAmount) {
         const topupRes = await fetch(ARC_API_BASE + '/api/core/topup-session', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ userId: viewerState.userId, expectFunds: true }),
+            body: JSON.stringify({ userId: viewerState.userId, expectFunds: true, ...circleProofFields() }),
         });
 
         if (!topupRes.ok) {
@@ -2789,7 +2812,7 @@ window.arcLeaveSession = async function () {
         await fetch(ARC_API_BASE + '/api/core/end-session', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ userId: viewerState.userId }),
+            body: JSON.stringify({ userId: viewerState.userId, ...circleProofFields() }),
         });
     } catch (_) { /* best effort */ }
 
@@ -2840,7 +2863,7 @@ window.arcTeardownOnNavigate = async function () {
             await fetch(ARC_API_BASE + '/api/core/end-session', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ userId: viewerState.userId }),
+                body: JSON.stringify({ userId: viewerState.userId, ...circleProofFields() }),
             });
         } catch (_) { }
     }
@@ -2974,7 +2997,7 @@ window.arcEndSession = async function () {
         if (endBtn) { endBtn.disabled = false; endBtn.innerText = 'Network Error - Retry'; }
     };
 
-    xhr.send(JSON.stringify({ userId: viewerState.userId }));
+    xhr.send(JSON.stringify({ userId: viewerState.userId, ...circleProofFields() }));
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -3005,7 +3028,7 @@ async function fetchTipBalance() {
     const userId = viewerState.userId;
     if (!userId) return null;
     try {
-        const res = await fetch(ARC_API_BASE + '/api/core/session-balance?userId=' + userId);
+        const res = await fetchSessionBalance(userId);
         if (!res.ok) return null;
         const data = await res.json();
         return Number(data.gatewayAvailable) || 0;
@@ -3199,13 +3222,13 @@ window.arcShowTipButton = function (creatorWallet, tipAmount) {
             await fetch(ARC_API_BASE + '/api/core/end-session', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ userId: viewerState.userId }),
+                body: JSON.stringify({ userId: viewerState.userId, ...circleProofFields() }),
             });
 
             const res = await fetch(ARC_API_BASE + '/api/core/cash-out', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ userId: viewerState.userId }),
+                body: JSON.stringify({ userId: viewerState.userId, ...circleProofFields() }),
             });
 
             if (res.ok) {


### PR DESCRIPTION
## Summary
- `cash-out`, `end-session`, `topup-session`, `session-status`, and `session-balance` require the same Circle ownership proof as tips (`userToken` + `returnAddress` matching the Gateway session).
- `session-balance` and `session-status` are POST with JSON body. 
- HMAC `start`/`stop` and tip auth are unchanged.
