### PR TITLE
feat(core): require USDC on prepare-deposit

### DIFF
--- a/src/core/circle-routes.spec.ts
+++ b/src/core/circle-routes.spec.ts
@@ -214,3 +214,83 @@ describe('POST /circle/prepare-external-withdraw', () => {
         }));
     });
 });
+
+const DEPOSIT_EPHEMERAL_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+describe('POST /circle/prepare-deposit', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('creates a USDC transfer even when another token has a larger balance', async () => {
+        const handler = getRouteHandler('/circle/prepare-deposit');
+        mockCircleClient.getWalletTokenBalance.mockResolvedValue({
+            data: {
+                tokenBalances: [
+                    { amount: '99', token: { id: OTHER_TOKEN_ID, symbol: 'ETH' } },
+                    usdcBalanceRow('5'),
+                ],
+            },
+        });
+        mockCircleClient.createTransaction.mockResolvedValue({
+            data: { challengeId: 'deposit-challenge' },
+        });
+        const { res, getStatus, getJson } = mockRes();
+        await handler({
+            body: {
+                userToken: 't',
+                walletId: 'w',
+                depositAmount: '1.5',
+                ephemeralPk: DEPOSIT_EPHEMERAL_PK,
+            },
+        } as Request, res);
+        expect(getStatus()).toBe(200);
+        expect(getJson().challengeId).toBe('deposit-challenge');
+        expect(mockCircleClient.createTransaction).toHaveBeenCalledWith(expect.objectContaining({
+            userToken: 't',
+            walletId: 'w',
+            tokenId: USDC_TOKEN_ID,
+            amounts: ['1.5'],
+            fee: { type: 'level', config: { feeLevel: 'HIGH' } },
+        }));
+        expect(mockCircleClient.createTransaction.mock.calls[0][0].tokenId).not.toBe(OTHER_TOKEN_ID);
+    });
+
+    it('rejects when the wallet has no USDC', async () => {
+        const handler = getRouteHandler('/circle/prepare-deposit');
+        mockCircleClient.getWalletTokenBalance.mockResolvedValue({
+            data: { tokenBalances: [{ amount: '9', token: { id: OTHER_TOKEN_ID, symbol: 'ETH' } }] },
+        });
+        const { res, getStatus, getJson } = mockRes();
+        await handler({
+            body: {
+                userToken: 't',
+                walletId: 'w',
+                depositAmount: '1',
+                ephemeralPk: DEPOSIT_EPHEMERAL_PK,
+            },
+        } as Request, res);
+        expect(getStatus()).toBe(400);
+        expect(getJson().error).toBe('USDC token not found in wallet');
+        expect(mockCircleClient.createTransaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects amount above USDC balance', async () => {
+        const handler = getRouteHandler('/circle/prepare-deposit');
+        mockCircleClient.getWalletTokenBalance.mockResolvedValue({
+            data: { tokenBalances: [usdcBalanceRow('0.5')] },
+        });
+        const { res, getStatus, getJson } = mockRes();
+        await handler({
+            body: {
+                userToken: 't',
+                walletId: 'w',
+                depositAmount: '1',
+                ephemeralPk: DEPOSIT_EPHEMERAL_PK,
+            },
+        } as Request, res);
+        expect(getStatus()).toBe(400);
+        expect(getJson().error).toContain('Insufficient USDC');
+        expect(mockCircleClient.createTransaction).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/circle-routes.ts
+++ b/src/core/circle-routes.ts
@@ -359,8 +359,6 @@ circleRouter.post('/circle/email-otp/request', circleRateLimiter, async (req: Re
         console.error(`[Circle] ❌ Email OTP request failed:`, error?.response?.data || error.message);
         return res.status(500).json({
             error: 'Failed to request email OTP. Confirm SMTP is configured in Circle Console.',
-            debugError: error.message,
-            debugData: error?.response?.data,
         });
     }
 });
@@ -389,8 +387,6 @@ circleRouter.post('/circle/social/device-token', circleRateLimiter, async (req: 
         console.error(`[Circle] ❌ Social device token failed:`, error?.response?.data || error.message);
         return res.status(500).json({
             error: 'Failed to create social login device token',
-            debugError: error.message,
-            debugData: error?.response?.data,
         });
     }
 });
@@ -431,8 +427,6 @@ circleRouter.post('/circle/email-otp/refresh', circleRateLimiter, async (req: Re
         console.error(`[Circle] ❌ Email OTP refresh failed:`, error?.response?.data || error.message);
         return res.status(401).json({
             error: 'Session expired. Sign in with email again.',
-            debugError: error.message,
-            debugData: error?.response?.data,
         });
     }
 });
@@ -554,7 +548,7 @@ circleRouter.post('/circle/get-wallet', circleRateLimiter, async (req: Request, 
             walletCreationLocks.delete(userId);
         }
         console.error(`[Circle] ❌ Failed to get/create wallet:`, error?.response?.data || error.message);
-        return res.status(500).json({ error: 'Failed to get or create Circle wallet', debugError: error.message, debugData: error?.response?.data });
+        return res.status(500).json({ error: 'Failed to get or create Circle wallet' });
     }
 });
 
@@ -573,27 +567,31 @@ circleRouter.post('/circle/prepare-deposit', circleRateLimiter, async (req: Requ
         const account = privateKeyToAccount(ephemeralPk as `0x${string}`);
         const ephemeralWalletAddress = account.address;
 
-        // Fetch token balance to get the correct tokenId (Circle API requires tokenId even for native tokens)
+        // Fetch token balances and transfer USDC only (never native / tokens[0]).
         const balancesRes = await circleClient.getWalletTokenBalance({
             walletId,
             userToken
         });
-
-        // Find the token holding the funds (should be Native token or USDC)
-        const tokens = balancesRes.data?.tokenBalances || [];
-        const fundedToken = tokens.find((t: any) => parseFloat(t.amount) >= parseFloat(depositAmount)) || tokens[0];
-
-        if (!fundedToken) {
-            return res.status(400).json({ error: 'Wallet has no tokens' });
+        const usdc = findUsdcTokenBalance(balancesRes.data?.tokenBalances as CircleTokenBalanceRow[] | undefined);
+        if (!usdc?.token?.id) {
+            return res.status(400).json({ error: 'USDC token not found in wallet' });
+        }
+        const usdcBalance = String(usdc.amount ?? '0');
+        const requested = Number(depositAmount);
+        if (!Number.isFinite(requested) || requested <= 0) {
+            return res.status(400).json({ error: 'Invalid deposit amount' });
+        }
+        if (Number(usdcBalance) < requested) {
+            return res.status(400).json({ error: `Insufficient USDC balance: wallet has ${usdcBalance}, requested ${depositAmount}` });
         }
 
         const transferRes = await circleClient.createTransaction({
             userToken,
             walletId,
-            tokenId: fundedToken.token.id,
+            tokenId: usdc.token.id,
             idempotencyKey: crypto.randomUUID(),
             destinationAddress: ephemeralWalletAddress,
-            amounts: [depositAmount],
+            amounts: [String(depositAmount)],
             fee: { type: 'level', config: { feeLevel: 'HIGH' } }
         });
 


### PR DESCRIPTION
## Summary
- `POST /circle/prepare-deposit` selects USDC via `findUsdcTokenBalance` instead of the first funded token
- Circle auth error JSON no longer returns `debugError` / `debugData`
- Unit tests cover USDC selection, missing USDC, and insufficient balance