### PR TITLE
chore(core): run build:ui in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,4 @@ jobs:
     - run: npm run typecheck
     - run: npm test
     - run: npm run build
+    - run: npm run build:ui


### PR DESCRIPTION
## Summary
- GitHub Actions runs `npm run build:ui` after `tsc`, matching the Docker build