### PR TITLE
feat(core): Circle Agent Stack caller support

### DIFF
--- a/CONNECTOR_SPEC.md
+++ b/CONNECTOR_SPEC.md
@@ -49,7 +49,11 @@ The plugin computes these before each POST:
 
 ### userId format (critical)
 
-`userId` is **not** your platform's native account id. Tessera assigns it after the viewer signs in through the paywall (Circle email OTP or Google).
+`userId` is **not** your platform's native account id.
+
+**Humans:** Tessera assigns it after the viewer signs in through the paywall (Circle email OTP or Google).
+
+**Agents:** the caller creates a Circle Agent Wallet on their side (`circle wallet login --testnet`). Tessera does **not** call `get-wallet` / `createUserPinWithWallets` for them. Use the `userId` returned by `POST /agent/begin-session`.
 
 Valid formats (7-256 chars):
 
@@ -57,9 +61,10 @@ Valid formats (7-256 chars):
 |---|---|---|
 | `email:` | `email:viewer@example.com` | Email OTP login |
 | `social:` | `social:104083036205001006721` | Google / Facebook login |
+| `agent:` | `agent:0x1111222233334444555566667777888899990000` | Circle Agent Stack wallet (EOA or SCA address) |
 | `arc_` | `arc_mlbogxpfyg` | Legacy sessions only |
 
-Invalid: `user-42`, PeerTube account ids, Jellyfin user ids, random UUIDs without a valid prefix.
+Invalid: `user-42`, PeerTube account ids, Jellyfin user ids, random UUIDs without a valid prefix, `agent_<uuid>`.
 
 **Rule:** the browser paywall and your server must use the **same** `userId`.
 
@@ -70,6 +75,22 @@ Invalid: `user-42`, PeerTube account ids, Jellyfin user ids, random UUIDs withou
 5. Your plugin server forwards the same `userId` in HMAC `start` / `stop` (and the browser sends it on `tips`).
 
 If you POST `start` before the viewer has logged in, or with a platform-native id, `register-session` and `tips` will fail.
+
+### Agent callers (Circle Agent Stack)
+
+Tessera does not create the agent's Circle wallet. The agent does that with Circle CLI, then proves ownership with a signed challenge (Circle CLI does not document exporting a `userToken`).
+
+1. `circle wallet login you@example.com --testnet` (wallets are created on all supported chains, including `ARC-TESTNET`).
+2. `circle wallet list --type agent --chain ARC-TESTNET` (copy the address).
+3. Testnet faucet: `circle wallet fund --address 0xAgent --chain ARC-TESTNET` (omit `--method` and `--amount`; Circle auto-funds 20 USDC).
+4. `POST {Base URL}/api/core/agent/challenge` with `{ "address": "0xAgent" }`.
+5. Sign `message` from that response: `circle wallet sign message "<message>" --address 0xAgent --chain ARC-TESTNET`.
+6. `POST {Base URL}/api/core/agent/begin-session` with `{ "address", "signature" }`. Response includes `userId` (`agent:0x...`) and `ephemeralAddress`. Tessera minted the Gateway ephemeral key. It did not create a Circle wallet.
+7. Transfer USDC from the agent wallet to `ephemeralAddress`: `circle wallet transfer <ephemeralAddress> --amount <usdc> --address 0xAgent --chain ARC-TESTNET`.
+8. `POST {Base URL}/api/core/agent/fund-session` with the same `{ "address", "signature" }` (challenge is valid for 10 minutes).
+9. Plugin HMAC `start` / `stop` with that `userId`. `start` returns **402** until step 8 succeeds.
+
+`POST /api/core/circle/get-wallet` with an `agent:` userId returns 400. Humans still use OTP/Google + `get-wallet`.
 
 ## 2. Browser UI and relay
 
@@ -415,6 +436,7 @@ Each entry is a `resourceId` your connector sent on `start` (or via `tips`) that
 | 400 | `start` | `splits` fractions sum > 1 |
 | 400 | `stop` | Missing `userId` |
 | 401 | `start`, `stop` | Missing/invalid HMAC, expired timestamp (> 60 s), or duplicate nonce |
+| 402 | `start` | `userId` is `agent:` and Gateway session is missing or still pending funds |
 | 400 | `tips` | Missing `userToken` or `returnAddress` |
 | 401 | `tips` | Circle session does not own `returnAddress`, or it does not match the stored Gateway session |
 | 402 | `tips` | Insufficient Gateway balance |

--- a/docs/connectors/spec.md
+++ b/docs/connectors/spec.md
@@ -49,7 +49,11 @@ The plugin computes these before each POST:
 
 ### userId format (critical)
 
-`userId` is **not** your platform's native account id. Tessera assigns it after the viewer signs in through the paywall (Circle email OTP or Google).
+`userId` is **not** your platform's native account id.
+
+**Humans:** Tessera assigns it after the viewer signs in through the paywall (Circle email OTP or Google).
+
+**Agents:** the caller creates a Circle Agent Wallet on their side (`circle wallet login --testnet`). Tessera does **not** call `get-wallet` / `createUserPinWithWallets` for them. Use the `userId` returned by `POST /agent/begin-session`.
 
 Valid formats (7-256 chars):
 
@@ -57,9 +61,10 @@ Valid formats (7-256 chars):
 |---|---|---|
 | `email:` | `email:viewer@example.com` | Email OTP login |
 | `social:` | `social:104083036205001006721` | Google / Facebook login |
+| `agent:` | `agent:0x1111222233334444555566667777888899990000` | Circle Agent Stack wallet (EOA or SCA address) |
 | `arc_` | `arc_mlbogxpfyg` | Legacy sessions only |
 
-Invalid: `user-42`, PeerTube account ids, Jellyfin user ids, random UUIDs without a valid prefix.
+Invalid: `user-42`, PeerTube account ids, Jellyfin user ids, random UUIDs without a valid prefix, `agent_<uuid>`.
 
 **Rule:** the browser paywall and your server must use the **same** `userId`.
 
@@ -70,6 +75,22 @@ Invalid: `user-42`, PeerTube account ids, Jellyfin user ids, random UUIDs withou
 5. Your plugin server forwards the same `userId` in HMAC `start` / `stop` (and the browser sends it on `tips`).
 
 If you POST `start` before the viewer has logged in, or with a platform-native id, `register-session` and `tips` will fail.
+
+### Agent callers (Circle Agent Stack)
+
+Tessera does not create the agent's Circle wallet. The agent does that with Circle CLI, then proves ownership with a signed challenge (Circle CLI does not document exporting a `userToken`).
+
+1. `circle wallet login you@example.com --testnet` (wallets are created on all supported chains, including `ARC-TESTNET`).
+2. `circle wallet list --type agent --chain ARC-TESTNET` (copy the address).
+3. Testnet faucet: `circle wallet fund --address 0xAgent --chain ARC-TESTNET` (omit `--method` and `--amount`; Circle auto-funds 20 USDC).
+4. `POST {Base URL}/api/core/agent/challenge` with `{ "address": "0xAgent" }`.
+5. Sign `message` from that response: `circle wallet sign message "<message>" --address 0xAgent --chain ARC-TESTNET`.
+6. `POST {Base URL}/api/core/agent/begin-session` with `{ "address", "signature" }`. Response includes `userId` (`agent:0x...`) and `ephemeralAddress`. Tessera minted the Gateway ephemeral key. It did not create a Circle wallet.
+7. Transfer USDC from the agent wallet to `ephemeralAddress`: `circle wallet transfer <ephemeralAddress> --amount <usdc> --address 0xAgent --chain ARC-TESTNET`.
+8. `POST {Base URL}/api/core/agent/fund-session` with the same `{ "address", "signature" }` (challenge is valid for 10 minutes).
+9. Plugin HMAC `start` / `stop` with that `userId`. `start` returns **402** until step 8 succeeds.
+
+`POST /api/core/circle/get-wallet` with an `agent:` userId returns 400. Humans still use OTP/Google + `get-wallet`.
 
 ## 2. Browser UI and relay
 
@@ -415,6 +436,7 @@ Each entry is a `resourceId` your connector sent on `start` (or via `tips`) that
 | 400 | `start` | `splits` fractions sum > 1 |
 | 400 | `stop` | Missing `userId` |
 | 401 | `start`, `stop` | Missing/invalid HMAC, expired timestamp (> 60 s), or duplicate nonce |
+| 402 | `start` | `userId` is `agent:` and Gateway session is missing or still pending funds |
 | 400 | `tips` | Missing `userToken` or `returnAddress` |
 | 401 | `tips` | Circle session does not own `returnAddress`, or it does not match the stored Gateway session |
 | 402 | `tips` | Insufficient Gateway balance |

--- a/src/core/agent-routes.spec.ts
+++ b/src/core/agent-routes.spec.ts
@@ -1,0 +1,150 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { getAddress } from 'viem';
+import { walletService } from './wallet';
+
+const mockGetBalances = vi.fn();
+const mockDeposit = vi.fn();
+
+vi.mock('@circle-fin/x402-batching/client', () => ({
+    GatewayClient: class {
+        getBalances = mockGetBalances;
+        deposit = mockDeposit;
+    },
+}));
+
+let agentRouter: any;
+let buildAgentChallengeMessage: (address: string, nonce: string, expiresAt: number) => string;
+
+beforeAll(async () => {
+    const mod = await import('./agent-routes');
+    agentRouter = mod.default;
+    buildAgentChallengeMessage = mod.buildAgentChallengeMessage;
+});
+
+function mockRes() {
+    let statusCode = 200;
+    let responseJson: any = null;
+    const res = {
+        status: (code: number) => {
+            statusCode = code;
+            return res;
+        },
+        json: (data: any) => {
+            responseJson = data;
+            return res;
+        },
+        setHeader: () => res,
+        send: (raw: string) => {
+            responseJson = JSON.parse(raw);
+            return res;
+        },
+    } as unknown as Response;
+    return {
+        res,
+        getStatus: () => statusCode,
+        getJson: () => responseJson,
+    };
+}
+
+function getRouteHandler(path: string) {
+    const layer = agentRouter.stack.find((s: any) => s.route && s.route.path === path);
+    return layer?.route?.stack[layer.route.stack.length - 1]?.handle;
+}
+
+describe('agent challenge message', () => {
+    it('includes chain, address, nonce, and expiry', () => {
+        const message = buildAgentChallengeMessage(
+            '0x1111222233334444555566667777888899990000',
+            'nonce-1',
+            Date.parse('2026-01-01T00:00:00.000Z'),
+        );
+        expect(message).toContain('Tessera agent session');
+        expect(message).toContain('Chain: ARC-TESTNET');
+        expect(message).toContain('Address: 0x1111222233334444555566667777888899990000');
+        expect(message).toContain('Nonce: nonce-1');
+        expect(message).toContain('Expires: 2026-01-01T00:00:00.000Z');
+    });
+});
+
+describe('POST /agent/challenge', () => {
+    it('rejects invalid address', async () => {
+        const handler = getRouteHandler('/agent/challenge');
+        const { res, getStatus, getJson } = mockRes();
+        await handler({ body: { address: 'not-an-address' } } as Request, res);
+        expect(getStatus()).toBe(400);
+        expect(getJson().error).toMatch(/address/i);
+    });
+
+    it('returns a signable message and agent userId', async () => {
+        const handler = getRouteHandler('/agent/challenge');
+        const address = '0x1111222233334444555566667777888899990000';
+        const { res, getStatus, getJson } = mockRes();
+        await handler({ body: { address } } as Request, res);
+        expect(getStatus()).toBe(200);
+        expect(getJson().status).toBe('challenge');
+        expect(getJson().userId).toBe(`agent:${getAddress(address)}`);
+        expect(getJson().message).toContain('Tessera agent session');
+        expect(getJson().signCommand).toContain('circle wallet sign message');
+    });
+});
+
+describe('POST /agent/begin-session', () => {
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+    const address = account.address;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('rejects a bad signature', async () => {
+        const challengeHandler = getRouteHandler('/agent/challenge');
+        const beginHandler = getRouteHandler('/agent/begin-session');
+        await challengeHandler({ body: { address } } as Request, mockRes().res);
+        const { res, getStatus } = mockRes();
+        await beginHandler({
+            body: { address, signature: '0x' + 'ab'.repeat(65) },
+        } as Request, res);
+        expect(getStatus()).toBe(401);
+    });
+
+    it('registers a pending session after a valid EOA signature', async () => {
+        const challengeHandler = getRouteHandler('/agent/challenge');
+        const beginHandler = getRouteHandler('/agent/begin-session');
+        const challengeRes = mockRes();
+        await challengeHandler({ body: { address } } as Request, challengeRes.res);
+        const message = challengeRes.getJson().message as string;
+        const signature = await account.signMessage({ message });
+
+        vi.spyOn(walletService, 'hasSessionRecord').mockReturnValue(false);
+        const registerSpy = vi.spyOn(walletService, 'registerSessionKey').mockImplementation(() => {});
+
+        const { res, getStatus, getJson } = mockRes();
+        await beginHandler({ body: { address, signature } } as Request, res);
+        expect(getStatus()).toBe(200);
+        expect(getJson().status).toBe('awaiting_funds');
+        expect(getJson().userId).toBe(`agent:${address}`);
+        expect(getJson().ephemeralAddress).toMatch(/^0x[a-fA-F0-9]{40}$/);
+        expect(registerSpy).toHaveBeenCalled();
+        expect(registerSpy.mock.calls[0][4]).toBe(true);
+    });
+});
+
+describe('POST /agent/fund-session', () => {
+    it('returns 404 when begin-session was not called', async () => {
+        const privateKey = generatePrivateKey();
+        const account = privateKeyToAccount(privateKey);
+        const address = account.address;
+        const challengeHandler = getRouteHandler('/agent/challenge');
+        const fundHandler = getRouteHandler('/agent/fund-session');
+        const challengeRes = mockRes();
+        await challengeHandler({ body: { address } } as Request, challengeRes.res);
+        const signature = await account.signMessage({ message: challengeRes.getJson().message });
+        vi.spyOn(walletService, 'hasSessionRecord').mockReturnValue(false);
+        const { res, getStatus } = mockRes();
+        await fundHandler({ body: { address, signature } } as Request, res);
+        expect(getStatus()).toBe(404);
+    });
+});

--- a/src/core/agent-routes.ts
+++ b/src/core/agent-routes.ts
@@ -1,0 +1,283 @@
+/**
+ * Agent callers (Circle Agent Stack).
+ *
+ * Humans create Circle SCAs through circle-routes + the paywall (OTP / Google).
+ * Agents create their wallet with Circle CLI on their side. Tessera never calls
+ * createUserPinWithWallets for them. Ownership is a signed challenge
+ * (`circle wallet sign message`).
+ */
+
+import { Router, type Request, type Response } from 'express';
+import crypto from 'crypto';
+import rateLimit from 'express-rate-limit';
+import { GatewayClient } from '@circle-fin/x402-batching/client';
+import {
+    createPublicClient,
+    getAddress,
+    http,
+    isAddress,
+    verifyMessage,
+    type Hex,
+} from 'viem';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { arcTestnet } from 'viem/chains';
+import { walletService } from './wallet';
+import { addressesEqual, agentUserIdFromAddress } from './session-key-auth';
+
+const ARC_RPC_URL = process.env.ARC_RPC_URL || 'https://rpc.testnet.arc.network';
+const CHALLENGE_TTL_MS = 10 * 60 * 1000;
+
+const publicClient = createPublicClient({
+    chain: arcTestnet,
+    transport: http(ARC_RPC_URL),
+});
+
+const agentLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many requests, please try again later.' },
+});
+
+interface AgentChallenge {
+    message: string;
+    nonce: string;
+    expiresAt: number;
+}
+
+const agentChallenges = new Map<string, AgentChallenge>();
+
+export function buildAgentChallengeMessage(address: string, nonce: string, expiresAt: number): string {
+    return [
+        'Tessera agent session',
+        'Chain: ARC-TESTNET',
+        `Address: ${address}`,
+        `Nonce: ${nonce}`,
+        `Expires: ${new Date(expiresAt).toISOString()}`,
+    ].join('\n');
+}
+
+async function verifyAgentSignature(
+    address: `0x${string}`,
+    message: string,
+    signature: string,
+): Promise<boolean> {
+    try {
+        const eoaOk = await verifyMessage({
+            address,
+            message,
+            signature: signature as Hex,
+        });
+        if (eoaOk) return true;
+    } catch {
+        // SCA signatures fail ecrecover; fall through to ERC-1271.
+    }
+    try {
+        return await publicClient.verifyMessage({
+            address,
+            message,
+            signature: signature as Hex,
+        });
+    } catch {
+        return false;
+    }
+}
+
+function readChecksumAddress(raw: unknown): `0x${string}` | null {
+    if (typeof raw !== 'string' || !isAddress(raw)) return null;
+    return getAddress(raw);
+}
+
+async function requireValidChallenge(
+    address: `0x${string}`,
+    signature: unknown,
+): Promise<{ ok: true; message: string } | { ok: false; status: number; error: string }> {
+    if (typeof signature !== 'string' || !signature.startsWith('0x')) {
+        return { ok: false, status: 400, error: 'Missing or invalid signature' };
+    }
+    const challenge = agentChallenges.get(address.toLowerCase());
+    if (!challenge) {
+        return { ok: false, status: 400, error: 'No challenge for this address. POST /agent/challenge first.' };
+    }
+    if (Date.now() > challenge.expiresAt) {
+        agentChallenges.delete(address.toLowerCase());
+        return { ok: false, status: 400, error: 'Challenge expired. Request a new one.' };
+    }
+    const valid = await verifyAgentSignature(address, challenge.message, signature);
+    if (!valid) {
+        return { ok: false, status: 401, error: 'Signature does not match this address.' };
+    }
+    return { ok: true, message: challenge.message };
+}
+
+const agentRouter = Router();
+
+/**
+ * POST /agent/challenge { address }
+ * Returns a plaintext message for `circle wallet sign message`.
+ */
+agentRouter.post('/agent/challenge', agentLimiter, (req: Request, res: Response) => {
+    const address = readChecksumAddress(req.body?.address);
+    if (!address) {
+        return res.status(400).json({ error: 'Missing or invalid address' });
+    }
+    const nonce = crypto.randomUUID();
+    const expiresAt = Date.now() + CHALLENGE_TTL_MS;
+    const message = buildAgentChallengeMessage(address, nonce, expiresAt);
+    agentChallenges.set(address.toLowerCase(), { message, nonce, expiresAt });
+    return res.json({
+        status: 'challenge',
+        address,
+        userId: agentUserIdFromAddress(address),
+        nonce,
+        expiresAt,
+        message,
+        signCommand: `circle wallet sign message ${JSON.stringify(message)} --address ${address} --chain ARC-TESTNET`,
+    });
+});
+
+/**
+ * POST /agent/begin-session { address, signature }
+ * Tessera mints the ephemeral Gateway key. The agent must fund that address,
+ * then call /agent/fund-session. Does not create a Circle wallet.
+ */
+agentRouter.post('/agent/begin-session', agentLimiter, async (req: Request, res: Response) => {
+    const address = readChecksumAddress(req.body?.address);
+    if (!address) {
+        return res.status(400).json({ error: 'Missing or invalid address' });
+    }
+    const proof = await requireValidChallenge(address, req.body?.signature);
+    if (!proof.ok) return res.status(proof.status).json({ error: proof.error });
+
+    const userId = agentUserIdFromAddress(address);
+
+    if (walletService.hasSessionRecord(userId)) {
+        const existing = walletService.getSessionRecord(userId);
+        if (!addressesEqual(existing.returnAddress, address)) {
+            return res.status(401).json({ error: 'Return address does not match existing session.' });
+        }
+        const account = privateKeyToAccount(existing.privateKey);
+        const funded = existing.pending !== true;
+        return res.json({
+            status: funded ? 'already_funded' : 'awaiting_funds',
+            userId,
+            returnAddress: address,
+            ephemeralAddress: account.address,
+        });
+    }
+
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+    walletService.registerSessionKey(userId, privateKey, address, undefined, true);
+
+    return res.json({
+        status: 'awaiting_funds',
+        userId,
+        returnAddress: address,
+        ephemeralAddress: account.address,
+        fundHint: `circle wallet transfer ${account.address} --amount <usdc> --address ${address} --chain ARC-TESTNET`,
+    });
+});
+
+/**
+ * POST /agent/fund-session { address, signature }
+ * Deposits ephemeral USDC into Gateway once the agent has transferred funds.
+ */
+agentRouter.post('/agent/fund-session', agentLimiter, async (req: Request, res: Response) => {
+    const address = readChecksumAddress(req.body?.address);
+    if (!address) {
+        return res.status(400).json({ error: 'Missing or invalid address' });
+    }
+    const proof = await requireValidChallenge(address, req.body?.signature);
+    if (!proof.ok) return res.status(proof.status).json({ error: proof.error });
+
+    const userId = agentUserIdFromAddress(address);
+    if (!walletService.hasSessionRecord(userId)) {
+        return res.status(404).json({ error: 'No agent session. POST /agent/begin-session first.' });
+    }
+    const sessionRecord = walletService.getSessionRecord(userId);
+    if (!addressesEqual(sessionRecord.returnAddress, address)) {
+        return res.status(401).json({ error: 'Return address does not match existing session.' });
+    }
+
+    const stringifyBigInt = (_key: string, value: unknown) => (typeof value === 'bigint' ? value.toString() : value);
+
+    try {
+        const gatewayClient = new GatewayClient({
+            privateKey: sessionRecord.privateKey,
+            chain: 'arcTestnet',
+            rpcUrl: ARC_RPC_URL,
+        });
+        let balances = await gatewayClient.getBalances();
+        let gatewayBalanceNum = Number(balances.gateway.formattedAvailable);
+        let walletUsdc = Number(balances.wallet.formatted);
+        const minWalletBalance = Number(process.env.MIN_WALLET_BALANCE || '0.01');
+        const minGatewayBalance = 0.01;
+
+        if (gatewayBalanceNum >= minGatewayBalance) {
+            walletService.markSessionFunded(userId);
+            agentChallenges.delete(address.toLowerCase());
+            return res.setHeader('Content-Type', 'application/json').send(
+                JSON.stringify({
+                    status: 'session_registered',
+                    userId,
+                    deposit: { txHash: 'skipped', amount: '0' },
+                    remainingBalance: balances.gateway.formattedAvailable,
+                }, stringifyBigInt),
+            );
+        }
+
+        if (gatewayBalanceNum < minGatewayBalance && walletUsdc < minWalletBalance) {
+            let attempts = 0;
+            while (attempts < 12 && walletUsdc < minWalletBalance) {
+                await new Promise((resolve) => setTimeout(resolve, 1500));
+                balances = await gatewayClient.getBalances();
+                walletUsdc = Number(balances.wallet.formatted);
+                attempts++;
+            }
+        }
+
+        if (walletUsdc < minWalletBalance) {
+            return res.status(400).json({
+                error: 'Ephemeral wallet has insufficient USDC. Transfer USDC to ephemeralAddress first.',
+            });
+        }
+
+        const retainedGasAmount = Number(process.env.RETAINED_GAS_AMOUNT || '0.01');
+        const depositAmount = Math.max(0, walletUsdc - retainedGasAmount).toFixed(6);
+        const depositResult = await gatewayClient.deposit(depositAmount);
+
+        let attempts = 0;
+        const expectedMinBalance = gatewayBalanceNum + Number(depositAmount);
+        while (attempts < 10) {
+            balances = await gatewayClient.getBalances();
+            gatewayBalanceNum = Number(balances.gateway.formattedAvailable);
+            if (gatewayBalanceNum >= expectedMinBalance) break;
+            attempts++;
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+        }
+        if (attempts >= 10) {
+            return res.status(500).json({ error: 'Timeout waiting for deposit to reflect in Gateway.' });
+        }
+
+        const finalBalances = await gatewayClient.getBalances();
+        walletService.markSessionFunded(userId);
+        agentChallenges.delete(address.toLowerCase());
+
+        return res.setHeader('Content-Type', 'application/json').send(
+            JSON.stringify({
+                status: 'session_registered',
+                userId,
+                deposit: { txHash: depositResult.depositTxHash, amount: depositResult.formattedAmount },
+                remainingBalance: finalBalances.gateway.formattedAvailable,
+            }, stringifyBigInt),
+        );
+    } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        console.error('[Agent] fund-session failed:', err.message);
+        return res.status(500).json({ error: err.message });
+    }
+});
+
+export default agentRouter;

--- a/src/core/circle-routes.spec.ts
+++ b/src/core/circle-routes.spec.ts
@@ -7,6 +7,7 @@ const mockCircleClient = {
     createTransaction: vi.fn(),
     getUserChallenge: vi.fn(),
     listWallets: vi.fn(),
+    createUserPinWithWallets: vi.fn(),
 };
 
 vi.mock('@circle-fin/user-controlled-wallets', () => ({
@@ -292,5 +293,22 @@ describe('POST /circle/prepare-deposit', () => {
         expect(getStatus()).toBe(400);
         expect(getJson().error).toContain('Insufficient USDC');
         expect(mockCircleClient.createTransaction).not.toHaveBeenCalled();
+    });
+});
+
+describe('POST /circle/get-wallet', () => {
+    it('does not create a Circle wallet for agent userIds', async () => {
+        const handler = getRouteHandler('/circle/get-wallet');
+        const { res, getStatus, getJson } = mockRes();
+        await handler({
+            body: {
+                userId: 'agent:0x1111222233334444555566667777888899990000',
+                userToken: 'x'.repeat(40),
+            },
+        } as Request, res);
+        expect(getStatus()).toBe(400);
+        expect(getJson().error).toMatch(/Agent Stack/i);
+        expect(mockCircleClient.listWallets).not.toHaveBeenCalled();
+        expect(mockCircleClient.createUserPinWithWallets).not.toHaveBeenCalled();
     });
 });

--- a/src/core/circle-routes.ts
+++ b/src/core/circle-routes.ts
@@ -30,6 +30,7 @@ import crypto from 'crypto';
 import { parse as parseCookie, serialize as serializeCookie } from 'cookie';
 import { privateKeyToAccount } from 'viem/accounts';
 import { initiateUserControlledWalletsClient } from '@circle-fin/user-controlled-wallets';
+import { isAgentUserId } from './session-key-auth';
 
 // ---------------------------------------------------------------------------
 // Circle SDK client
@@ -441,6 +442,11 @@ circleRouter.post('/circle/get-wallet', circleRateLimiter, async (req: Request, 
 
     if (!userId || !userToken) {
         return res.status(400).json({ error: 'Missing userId or userToken' });
+    }
+    if (isAgentUserId(userId)) {
+        return res.status(400).json({
+            error: 'Agent wallets are created by Circle Agent Stack on the caller side. Tessera does not create them.',
+        });
     }
 
     // Viewer auth is email OTP or social login only. Wallet creation uses the

--- a/src/core/routes.spec.ts
+++ b/src/core/routes.spec.ts
@@ -382,3 +382,46 @@ describe('POST /session-balance', () => {
         expect(getJson().error).toMatch(/Missing/);
     });
 });
+
+describe('POST /v1/sessions/start', () => {
+    const payoutAddress = '0x1111222233334444555566667777888899990000';
+    let handler: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        handler = getRouteHandler('/v1/sessions/start');
+    });
+
+    it('starts a human session without an agent funding check', async () => {
+        const join = vi.spyOn(sessionService, 'recordJoin').mockImplementation(() => {});
+        const { res, getStatus, getJson } = mockRes();
+        await handler({
+            body: {
+                userId: 'email:viewer@example.com',
+                resourceId: 'video-1',
+                ratePerSecond: '0.000100',
+                payoutAddress,
+            },
+        } as Request, res);
+        expect(getStatus()).toBe(200);
+        expect(getJson()).toEqual({ status: 'session_started', sessionId: 'email:viewer@example.com' });
+        expect(join).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 402 when an agent session is not funded', async () => {
+        vi.spyOn(walletService, 'isSessionUnfunded').mockReturnValue(true);
+        const join = vi.spyOn(sessionService, 'recordJoin').mockImplementation(() => {});
+        const { res, getStatus, getJson } = mockRes();
+        await handler({
+            body: {
+                userId: 'agent:0x1111222233334444555566667777888899990000',
+                resourceId: 'deep_web_research',
+                ratePerSecond: '0.002',
+                payoutAddress,
+            },
+        } as Request, res);
+        expect(getStatus()).toBe(402);
+        expect(getJson().error).toMatch(/not funded/i);
+        expect(join).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/routes.ts
+++ b/src/core/routes.ts
@@ -7,7 +7,7 @@ import { statsService } from './stats';
 import { GATEWAY_FEE_BUFFER } from './gateway-utils';
 import creatorRouter from './creator-routes';
 import { verifyCircleWalletOwnership } from './circle-routes';
-import { addressesEqual, isValidPrivateKeyHex, isValidViewerUserId } from './session-key-auth';
+import { addressesEqual, isAgentUserId, isValidPrivateKeyHex, isValidViewerUserId } from './session-key-auth';
 import { verifyIngestSignature } from './security/verify-ingest-signature';
 import rateLimit from 'express-rate-limit';
 import { isAddress, isHex, createPublicClient, http, formatUnits, parseUnits } from 'viem';
@@ -151,6 +151,11 @@ coreRouter.post('/v1/sessions/start', sessionLimiter, verifyIngestSignature, (re
             if (typeof split.fraction !== 'number' || split.fraction < 0 || split.fraction > 1)
                 return res.status(400).json({ error: `Invalid split fraction: ${split?.fraction}` });
         }
+    }
+    if (isAgentUserId(userId) && walletService.isSessionUnfunded(userId)) {
+        return res.status(402).json({
+            error: 'Agent Gateway session is not funded. Complete POST /api/core/agent/fund-session first.',
+        });
     }
 
     try {

--- a/src/core/session-key-auth.spec.ts
+++ b/src/core/session-key-auth.spec.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
     addressesEqual,
+    agentUserIdFromAddress,
+    isAgentUserId,
     isValidPrivateKeyHex,
     isValidViewerUserId,
+    parseAgentAddress,
 } from './session-key-auth';
 
 describe('session-key-auth', () => {
@@ -12,10 +15,21 @@ describe('session-key-auth', () => {
         expect(isValidViewerUserId('arc_mlbogxpfyg')).toBe(true);
     });
 
+    it('accepts agent userIds with an EVM address', () => {
+        const addr = '0x1111222233334444555566667777888899990000';
+        expect(isAgentUserId(`agent:${addr}`)).toBe(true);
+        expect(isValidViewerUserId(`agent:${addr}`)).toBe(true);
+        expect(parseAgentAddress(`agent:${addr}`)).toBe(addr);
+        expect(agentUserIdFromAddress(addr)).toBe(`agent:${addr}`);
+    });
+
     it('rejects invalid userIds', () => {
         expect(isValidViewerUserId('')).toBe(false);
         expect(isValidViewerUserId('user')).toBe(false);
         expect(isValidViewerUserId('email:')).toBe(false);
+        expect(isValidViewerUserId('agent_abc')).toBe(false);
+        expect(isValidViewerUserId('agent:0x123')).toBe(false);
+        expect(isAgentUserId('email:a@b.com')).toBe(false);
         expect(isValidViewerUserId(null)).toBe(false);
     });
 

--- a/src/core/session-key-auth.ts
+++ b/src/core/session-key-auth.ts
@@ -1,7 +1,25 @@
 /**
  * Helpers for viewer session-key auth (ephemeral sync / register).
- * Pure checks only — Circle ownership lives in circle-routes.
+ * Pure checks only. Circle ownership lives in circle-routes.
  */
+
+const AGENT_PREFIX = 'agent:';
+const EVM_ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+
+export function isAgentUserId(userId: unknown): userId is string {
+    if (typeof userId !== 'string') return false;
+    if (!userId.startsWith(AGENT_PREFIX)) return false;
+    return EVM_ADDRESS_RE.test(userId.slice(AGENT_PREFIX.length));
+}
+
+export function parseAgentAddress(userId: string): string | null {
+    if (!isAgentUserId(userId)) return null;
+    return userId.slice(AGENT_PREFIX.length);
+}
+
+export function agentUserIdFromAddress(address: string): string {
+    return `${AGENT_PREFIX}${address}`;
+}
 
 export function isValidViewerUserId(userId: unknown): userId is string {
     if (typeof userId !== 'string') return false;
@@ -9,6 +27,7 @@ export function isValidViewerUserId(userId: unknown): userId is string {
     if (userId.startsWith('email:')) return userId.length > 'email:'.length;
     if (userId.startsWith('social:')) return userId.length > 'social:'.length;
     if (userId.startsWith('arc_')) return userId.length > 'arc_'.length;
+    if (isAgentUserId(userId)) return true;
     return false;
 }
 

--- a/src/core/wallet.spec.ts
+++ b/src/core/wallet.spec.ts
@@ -73,4 +73,15 @@ describe('WalletService', () => {
         const fileContent = fs.readFileSync(DB_PATH, 'utf-8');
         expect(fileContent.startsWith('{')).toBe(false);
     });
+
+    it('tracks pending agent sessions until markSessionFunded', () => {
+        const userId = 'agent:0x1111222233334444555566667777888899990000';
+        expect(walletService.isSessionUnfunded(userId)).toBe(true);
+        walletService.registerSessionKey(userId, '0x123', '0xabc', undefined, true);
+        expect(walletService.getSessionRecord(userId).pending).toBe(true);
+        expect(walletService.isSessionUnfunded(userId)).toBe(true);
+        walletService.markSessionFunded(userId);
+        expect(walletService.getSessionRecord(userId).pending).toBeUndefined();
+        expect(walletService.isSessionUnfunded(userId)).toBe(false);
+    });
 });

--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -7,6 +7,8 @@ export interface SessionRecord {
     privateKey: Hex;
     returnAddress: string;
     sourceChain?: string;
+    /** Agent sessions only: true until /agent/fund-session deposits into Gateway. */
+    pending?: boolean;
 }
 
 const DATA_DIR = path.resolve(process.cwd(), 'data');
@@ -126,16 +128,38 @@ export class WalletService {
     }
 
     /**
-     * Registers a funded ephemeral key and return address for a user.
+     * Registers an ephemeral Gateway key and return address for a user.
+     * Pass pending=true for agent sessions that still need /agent/fund-session.
      */
-    public registerSessionKey(userId: string, privateKey: string, returnAddress: string, sourceChain?: string): void {
-        this.sessionRecords.set(userId, {
+    public registerSessionKey(userId: string, privateKey: string, returnAddress: string, sourceChain?: string, pending = false): void {
+        const record: SessionRecord = {
             privateKey: privateKey as Hex,
             returnAddress,
-            sourceChain
-        });
+            sourceChain,
+        };
+        if (pending) record.pending = true;
+        this.sessionRecords.set(userId, record);
         this.saveDb();
-        console.log(`[Wallet] 🔐 Ephemeral Key registered for user: ${userId}`);
+        console.log(`[Wallet] Ephemeral key registered for user: ${userId}${pending ? ' (pending funds)' : ''}`);
+    }
+
+    /**
+     * Clears the pending flag after a successful Gateway deposit.
+     */
+    public markSessionFunded(userId: string): void {
+        const record = this.getSessionRecord(userId);
+        if (!record.pending) return;
+        delete record.pending;
+        this.sessionRecords.set(userId, record);
+        this.saveDb();
+    }
+
+    /**
+     * True when no record exists, or the record is still waiting for Gateway deposit.
+     */
+    public isSessionUnfunded(userId: string): boolean {
+        if (!this.hasSessionRecord(userId)) return true;
+        return this.getSessionRecord(userId).pending === true;
     }
 
     /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import coreRouter from './core/routes';
 import circleRouter from './core/circle-routes';
+import agentRouter from './core/agent-routes';
 import instanceInfoRouter from './core/instance-info';
 import { sessionService } from './core/session';
 import { TESSERA_VERSION } from './version';
@@ -51,6 +52,7 @@ export async function createServer() {
 
     app.use('/api/core', coreRouter);
     app.use('/api/core', circleRouter);
+    app.use('/api/core', agentRouter);
     app.use('/api/tessera', instanceInfoRouter);
 
     app.get('/health', async (_req, res) => {


### PR DESCRIPTION
## Summary

Adds support for AI agents using Circle Agent Stack as Tessera callers, without touching the existing human viewer flow.

## What changed

### New: Agent onboarding endpoints (src/core/agent-routes.ts)

| Endpoint | Description |
|---|---|
| \POST /api/core/agent/challenge\ | Issues a plaintext challenge message (10 min TTL) for the agent to sign with \circle wallet sign message\ |
| \POST /api/core/agent/begin-session\ | Verifies the signature (EOA + EIP-1271 fallback for SCA), mints an ephemeral Gateway key, returns \userId\ and \ephemeralAddress\ |
| \POST /api/core/agent/fund-session\ | Polls the ephemeral wallet for USDC, deposits into Gateway, marks session funded |

### Modified files

- \session-key-auth.ts\ - adds \isAgentUserId\, \parseAgentAddress\, \gentUserIdFromAddress\; extends \isValidViewerUserId\ to accept \gent:0x...\ prefix
- \wallet.ts\ - adds \SessionRecord.pending\ flag; \markSessionFunded()\ and \isSessionUnfunded()\
- \
outes.ts\ - \POST /v1/sessions/start\ returns 402 when agent session is unfunded
- \circle-routes.ts\ - \POST /circle/get-wallet\ returns 400 for \gent:\ userIds
- \server.ts\ - registers \gentRouter\ at \/api/core\
- \CONNECTOR_SPEC.md\ / \docs/connectors/spec.md\ - documents \gent:0x...\ userId format, full onboarding flow, and new 402 error code

## Design decisions

- Tessera never calls \createUserPinWithWallets\ for agents. The agent creates its own Circle wallet via \circle wallet login\.
- Ownership is proven with a signed challenge, not a userToken (Circle CLI does not export userToken).
- Signature verification handles both EOA (viem \erifyMessage\) and SCA (EIP-1271 via \publicClient.verifyMessage\).
- Agent sessions are marked \pending\ until \/agent/fund-session\ confirms a Gateway deposit. \POST /v1/sessions/start\ returns 402 until then.

## Risks

- The challenge TTL (10 min) is reused for \und-session\. If the USDC transfer takes longer, the agent must restart from \/agent/challenge\.
- Gateway deposit polling (12 x 1500ms for wallet, 10 x 1500ms for deposit) adds latency to \und-session\. Acceptable for a one-time setup flow.

## Testing

- 65/65 tests pass (\itest run src\)
- \
pm run lint\ - 0 errors
- \
pm run typecheck\ - clean

## Do not merge until

Manual end-to-end test with a real Circle Agent wallet on ARC-TESTNET.